### PR TITLE
Build `arm64-apple-darwin` on the CI

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -1,4 +1,4 @@
-name: Build Binaries
+name: Build binaries
 
 on:
   workflow_dispatch:
@@ -30,10 +30,10 @@ jobs:
       - uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.PUBLIC_REPO_TOKEN }}
-          commit-message: "Rebuild binaries for ${{ inputs.libwebp_ref }}"
+          commit-message: "Build libwebp binaries. version ${{ inputs.libwebp_ref }}"
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           delete-branch: true
-          title: "Rebuild binaries for libwebp version ${{ inputs.libwebp_ref }}"
+          title: "Build libwebp binaries, version `${{ inputs.libwebp_ref }}`"
           body: |
-            Rebuild binaries based on https://chromium.googlesource.com/webm/libwebp/+/refs/tags/${{ inputs.libwebp_ref }}
+            Build libwebp binaries, version [${{ inputs.libwebp_ref }}](https://chromium.googlesource.com/webm/libwebp/+/refs/tags/${{ inputs.libwebp_ref }})

--- a/libwebp-jni/compile-all.sh
+++ b/libwebp-jni/compile-all.sh
@@ -11,4 +11,5 @@
 ./dockcross/dockcross-windows-static-x64 bash -c './compile.sh Windows x86_64'
 
 docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=x86_64-apple-darwin gotson/crossbuild ./compile.sh Mac x86_64 /workdir/multiarch-darwin.cmake
+docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=arm64-apple-darwin gotson/crossbuild ./compile.sh Mac aarch64 /workdir/multiarch-darwin.cmake
 cp -r build/native ../webp-imageio/src/main/resources/

--- a/libwebp-jni/compile-all.sh
+++ b/libwebp-jni/compile-all.sh
@@ -12,4 +12,5 @@
 
 docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=x86_64-apple-darwin gotson/crossbuild ./compile.sh Mac x86_64 /workdir/multiarch-darwin.cmake
 docker run --rm -v $(pwd):/workdir -e CROSS_TRIPLE=arm64-apple-darwin gotson/crossbuild ./compile.sh Mac aarch64 /workdir/multiarch-darwin.cmake
+rm -r ../webp-imageio/src/main/resources/native
 cp -r build/native ../webp-imageio/src/main/resources/


### PR DESCRIPTION
- Build  `arm64-apple-darwin` on the CI
- Ensure no binaries are left
- Update PR content
