### PR TITLE
Migrate away from deprecated finalize() method in favour of a single `Cleaner`. Require Java 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/usefulness/webp-imageio/actions/workflows/after_merge.yml/badge.svg?branch=master)](https://github.com/usefulness/webp-imageio/actions/workflows/after_merge.yml)
 ![Maven Central](https://img.shields.io/maven-central/v/com.github.usefulness/webp-imageio)
-![Static Badge](https://img.shields.io/badge/java-8-blue)
+![Static Badge](https://img.shields.io/badge/java-9-blue)
 
 ## Description
 
@@ -174,4 +174,4 @@ writer.write(null, new IIOImage(image, null, null), writeParam);
 
 `webp-imageio` is distributed under the [Apache Software License](https://www.apache.org/licenses/LICENSE-2.0) version
 2.0.  
-`libwebp` binaries is distributed under the [Following License](https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.3.0/COPYING)
+`libwebp` binaries are distributed under the [Following License](https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.3.0/COPYING)

--- a/webp-imageio/api/webp-imageio.api
+++ b/webp-imageio/api/webp-imageio.api
@@ -52,7 +52,7 @@ public final class com/luciad/imageio/webp/WebPReadParam : javax/imageio/ImageRe
 	public final fun setUseThreads (Z)V
 }
 
-public class com/luciad/imageio/webp/WebPWriteParam : javax/imageio/ImageWriteParam {
+public final class com/luciad/imageio/webp/WebPWriteParam : javax/imageio/ImageWriteParam {
 	public static final field Companion Lcom/luciad/imageio/webp/WebPWriteParam$Companion;
 	public static final field LOSSLESS_COMPRESSION I
 	public static final field LOSSY_COMPRESSION I
@@ -60,63 +60,63 @@ public class com/luciad/imageio/webp/WebPWriteParam : javax/imageio/ImageWritePa
 	public static final field PREPROCESSING_FILTER_PSEUDO_RANDOM_DITHERING I
 	public static final field PREPROCESSING_FILTER_SEGMENT_SMOOTH I
 	public fun <init> (Ljava/util/Locale;)V
-	public fun getAlphaCompressionAlgorithm ()I
-	public fun getAlphaFiltering ()I
-	public fun getAlphaQuality ()I
-	public fun getAutoAdjustFilterStrength ()Z
+	public final fun getAlphaCompressionAlgorithm ()I
+	public final fun getAlphaFiltering ()I
+	public final fun getAlphaQuality ()I
+	public final fun getAutoAdjustFilterStrength ()Z
 	public fun getCompressionQuality ()F
 	public final fun getCompressionType ()Lcom/luciad/imageio/webp/CompressionType;
-	public fun getEmulateJpegSize ()Z
-	public fun getEntropyAnalysisPassCount ()I
-	public fun getExact ()Z
-	public fun getFilterSharpness ()I
-	public fun getFilterStrength ()I
-	public fun getFilterType ()I
-	public fun getLowMemory ()Z
-	public fun getMethod ()I
-	public fun getNearLossless ()I
-	public fun getPartitionLimit ()I
-	public fun getPartitions ()I
-	public fun getPreprocessing ()I
-	public fun getQMax ()I
-	public fun getQMin ()I
-	public fun getSegments ()I
-	public fun getShowCompressed ()Z
-	public fun getSnsStrength ()I
-	public fun getTargetPSNR ()F
-	public fun getTargetSize ()I
-	public fun getThreadLevel ()I
-	public fun getUseDeltaPalette ()Z
-	public fun getUseSharpYUV ()Z
-	public fun setAlphaCompressionAlgorithm (I)V
-	public fun setAlphaFiltering (I)V
-	public fun setAlphaQuality (I)V
-	public fun setAutoAdjustFilterStrength (Z)V
+	public final fun getEmulateJpegSize ()Z
+	public final fun getEntropyAnalysisPassCount ()I
+	public final fun getExact ()Z
+	public final fun getFilterSharpness ()I
+	public final fun getFilterStrength ()I
+	public final fun getFilterType ()I
+	public final fun getLowMemory ()Z
+	public final fun getMethod ()I
+	public final fun getNearLossless ()I
+	public final fun getPartitionLimit ()I
+	public final fun getPartitions ()I
+	public final fun getPreprocessing ()I
+	public final fun getQMax ()I
+	public final fun getQMin ()I
+	public final fun getSegments ()I
+	public final fun getShowCompressed ()Z
+	public final fun getSnsStrength ()I
+	public final fun getTargetPSNR ()F
+	public final fun getTargetSize ()I
+	public final fun getThreadLevel ()I
+	public final fun getUseDeltaPalette ()Z
+	public final fun getUseSharpYUV ()Z
+	public final fun setAlphaCompressionAlgorithm (I)V
+	public final fun setAlphaFiltering (I)V
+	public final fun setAlphaQuality (I)V
+	public final fun setAutoAdjustFilterStrength (Z)V
 	public fun setCompressionQuality (F)V
 	public final fun setCompressionType (Lcom/luciad/imageio/webp/CompressionType;)V
 	public fun setCompressionType (Ljava/lang/String;)V
-	public fun setEmulateJpegSize (Z)V
-	public fun setEntropyAnalysisPassCount (I)V
-	public fun setExact (Z)V
-	public fun setFilterSharpness (I)V
-	public fun setFilterStrength (I)V
-	public fun setFilterType (I)V
-	public fun setLowMemory (Z)V
-	public fun setMethod (I)V
-	public fun setNearLossless (I)V
-	public fun setPartitionLimit (I)V
-	public fun setPartitions (I)V
-	public fun setPreprocessing (I)V
-	public fun setQMax (I)V
-	public fun setQMin (I)V
-	public fun setSegments (I)V
-	public fun setShowCompressed (Z)V
-	public fun setSnsStrength (I)V
-	public fun setTargetPSNR (F)V
-	public fun setTargetSize (I)V
-	public fun setThreadLevel (I)V
-	public fun setUseDeltaPalette (Z)V
-	public fun setUseSharpYUV (Z)V
+	public final fun setEmulateJpegSize (Z)V
+	public final fun setEntropyAnalysisPassCount (I)V
+	public final fun setExact (Z)V
+	public final fun setFilterSharpness (I)V
+	public final fun setFilterStrength (I)V
+	public final fun setFilterType (I)V
+	public final fun setLowMemory (Z)V
+	public final fun setMethod (I)V
+	public final fun setNearLossless (I)V
+	public final fun setPartitionLimit (I)V
+	public final fun setPartitions (I)V
+	public final fun setPreprocessing (I)V
+	public final fun setQMax (I)V
+	public final fun setQMin (I)V
+	public final fun setSegments (I)V
+	public final fun setShowCompressed (Z)V
+	public final fun setSnsStrength (I)V
+	public final fun setTargetPSNR (F)V
+	public final fun setTargetSize (I)V
+	public final fun setThreadLevel (I)V
+	public final fun setUseDeltaPalette (Z)V
+	public final fun setUseSharpYUV (Z)V
 	public fun unsetCompression ()V
 }
 

--- a/webp-imageio/build.gradle
+++ b/webp-imageio/build.gradle
@@ -10,7 +10,7 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 
-def targetJavaVersion = JavaVersion.VERSION_1_8
+def targetJavaVersion = JavaVersion.VERSION_1_9
 tasks.withType(JavaCompile).configureEach {
     options.release.set(targetJavaVersion.majorVersion.toInteger())
     options.headerOutputDirectory.set(rootProject.file("libwebp-jni/src/main/c"))
@@ -34,7 +34,7 @@ tasks.register("generateVersionProperties", WriteProperties) { WriteProperties p
     props.property("webp_imageio_version", version)
 }
 
-[8, 11, 17].forEach { majorVersion ->
+[9, 11, 17].forEach { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
@@ -15,7 +15,7 @@
  */
 package com.luciad.imageio.webp;
 
-final class WebPDecoderOptions implements AutoCloseable {
+final class WebPDecoderOptions implements Runnable {
 
   long fPointer;
 
@@ -27,13 +27,7 @@ final class WebPDecoderOptions implements AutoCloseable {
   }
 
   @Override
-  protected void finalize() throws Throwable {
-    super.finalize();
-    close();
-  }
-
-  @Override
-  public void close() {
+  public void run() {
     deleteDecoderOptions(fPointer);
     fPointer = 0L;
   }

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
@@ -15,8 +15,7 @@
  */
 package com.luciad.imageio.webp;
 
-
-final class WebPEncoderOptions implements AutoCloseable {
+final class WebPEncoderOptions implements Runnable {
 
   long fPointer;
 
@@ -28,13 +27,7 @@ final class WebPEncoderOptions implements AutoCloseable {
   }
 
   @Override
-  protected void finalize() throws Throwable {
-    super.finalize();
-    close();
-  }
-
-  @Override
-  public void close() {
+  public void run() {
     deleteConfig(fPointer);
     fPointer = 0L;
   }

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/CompressionType.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/CompressionType.kt
@@ -7,6 +7,6 @@ public enum class CompressionType(internal val imageIoValue: String) {
 
     internal companion object {
 
-        val imageIoCompressionTypes = values().map { it.imageIoValue }.toTypedArray()
+        val imageIoCompressionTypes = entries.map { it.imageIoValue }.toTypedArray()
     }
 }

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPReadParam.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPReadParam.kt
@@ -7,6 +7,10 @@ public class WebPReadParam : ImageReadParam() {
 
     internal val decoderOptions = WebPDecoderOptions()
 
+    init {
+        WebPWrapper.cleaner.register(this, decoderOptions)
+    }
+
     /**
      * if true, skip the in-loop filtering
      */

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
@@ -4,7 +4,7 @@ import com.luciad.imageio.webp.WebPWrapper.loadNativeLibrary
 import java.util.Locale
 import javax.imageio.ImageWriteParam
 
-public open class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
+public class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
 
     internal val encoderOptions = WebPEncoderOptions()
     private val defaultLossless = encoderOptions.lossless
@@ -56,142 +56,142 @@ public open class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
     /**
      * quality/speed trade-off (0=fast, 6=slower-better)
      */
-    public open var method: Int by encoderOptions::method
+    public var method: Int by encoderOptions::method
 
     /**
      * if non-zero, set the desired target size in bytes.
      * Takes precedence over the @[.setCompressionQuality] parameter.
      */
-    public open var targetSize: Int by encoderOptions::targetSize
+    public var targetSize: Int by encoderOptions::targetSize
 
     /**
      * if non-zero, specifies the minimal distortion to try to achieve.
      * Takes precedence over [.setTargetSize].
      */
-    public open var targetPSNR: Float by encoderOptions::targetPSNR
+    public var targetPSNR: Float by encoderOptions::targetPSNR
 
     /**
      * maximum number of segments to use
      */
-    public open var segments: Int by encoderOptions::segments
+    public var segments: Int by encoderOptions::segments
 
     /**
      * Spatial Noise Shaping. 0=off, 100=maximum.
      */
-    public open var snsStrength: Int by encoderOptions::snsStrength
+    public var snsStrength: Int by encoderOptions::snsStrength
 
     /**
      * range: [0 = off .. 100 = strongest]
      */
-    public open var filterStrength: Int by encoderOptions::filterStrength
+    public var filterStrength: Int by encoderOptions::filterStrength
 
     /**
      * range: [0 = off .. 7 = least sharp]
      */
-    public open var filterSharpness: Int by encoderOptions::filterSharpness
+    public var filterSharpness: Int by encoderOptions::filterSharpness
 
     /**
      * filtering type: 0 = simple, 1 = strong (only used if filter_strength > 0 or autofilter > 0)
      */
-    public open var filterType: Int by encoderOptions::filterType
+    public var filterType: Int by encoderOptions::filterType
 
     /**
      * Auto adjust filter's strength
      */
-    public open var autoAdjustFilterStrength: Boolean by encoderOptions::autoAdjustFilterStrength
+    public var autoAdjustFilterStrength: Boolean by encoderOptions::autoAdjustFilterStrength
 
     /**
      * Algorithm for encoding the alpha plane
      * (0 = none, 1 = compressed with WebP lossless). Default is 1.
      */
-    public open var alphaCompressionAlgorithm: Int by encoderOptions::alphaCompressionAlgorithm
+    public var alphaCompressionAlgorithm: Int by encoderOptions::alphaCompressionAlgorithm
 
     /**
      * Predictive filtering method for alpha plane.
      * 0: none, 1: fast, 2: best. Default if 1.
      */
-    public open var alphaFiltering: Int by encoderOptions::alphaFiltering
+    public var alphaFiltering: Int by encoderOptions::alphaFiltering
 
     /**
      * 0: smallest size, 100: lossless. Default is 100.
      */
-    public open var alphaQuality: Int by encoderOptions::alphaQuality
+    public var alphaQuality: Int by encoderOptions::alphaQuality
 
     /**
      * Number of entropy-analysis passes
      */
-    public open var entropyAnalysisPassCount: Int by encoderOptions::entropyAnalysisPassCount
+    public var entropyAnalysisPassCount: Int by encoderOptions::entropyAnalysisPassCount
 
     /**
      * if true, export the compressed picture back. In-loop filtering is not applied.
      */
-    public open var showCompressed: Boolean by encoderOptions::showCompressed
+    public var showCompressed: Boolean by encoderOptions::showCompressed
 
     /**
      * Preprocessing filter
      * 0=none, 1=segment-smooth, 2=pseudo-random dithering
      */
-    public open var preprocessing: Int by encoderOptions::preprocessing
+    public var preprocessing: Int by encoderOptions::preprocessing
 
     /**
      * log2(number of token partitions) in [0..3]. Default is set to 0 for easier progressive decoding.
      */
-    public open var partitions: Int by encoderOptions::partitions
+    public var partitions: Int by encoderOptions::partitions
 
     /**
      * Quality degradation allowed to fit the 512k limit on prediction modes coding
      * 0: no degradation, 100: maximum possible degradation
      */
-    public open var partitionLimit: Int by encoderOptions::partitionLimit
+    public var partitionLimit: Int by encoderOptions::partitionLimit
 
     /**
      * If true, compression parameters will be remapped to better match the expected output size from
      * JPEG compression. Generally, the output size will be similar but the degradation will be lower.
      */
-    public open var emulateJpegSize: Boolean by encoderOptions::emulateJpegSize
+    public var emulateJpegSize: Boolean by encoderOptions::emulateJpegSize
 
     /**
      * If non-zero, try and use multi-threaded encoding.
      */
-    public open var threadLevel: Int by encoderOptions::threadLevel
+    public var threadLevel: Int by encoderOptions::threadLevel
 
     /**
      * If set, reduce memory usage (but increase CPU use).
      */
-    public open var lowMemory: Boolean by encoderOptions::lowMemory
+    public var lowMemory: Boolean by encoderOptions::lowMemory
 
     /**
      * Near lossless encoding
      * 0 = max loss, 100 = off (default)
      */
-    public open var nearLossless: Int by encoderOptions::nearLossless
+    public var nearLossless: Int by encoderOptions::nearLossless
 
     /**
      * If non-zero, preserve the exact RGB values under transparent area.
      * Otherwise, discard this invisible RGB information for better compression.
      * The default value is false.
      */
-    public open var exact: Boolean by encoderOptions::exact
+    public var exact: Boolean by encoderOptions::exact
 
     /**
      * reserved for future lossless feature
      */
-    public open var useDeltaPalette: Boolean by encoderOptions::useDeltaPalette
+    public var useDeltaPalette: Boolean by encoderOptions::useDeltaPalette
 
     /**
      * if needed, use sharp (and slow) RGB->YUV conversion
      */
-    public open var useSharpYUV: Boolean by encoderOptions::useSharpYUV
+    public var useSharpYUV: Boolean by encoderOptions::useSharpYUV
 
     /**
      * minimum permissible quality factor
      */
-    public open var qMin: Int by encoderOptions::qMin
+    public var qMin: Int by encoderOptions::qMin
 
     /**
      * maximum permissible quality factor
      */
-    public open var qMax: Int by encoderOptions::qMax
+    public var qMax: Int by encoderOptions::qMax
 
     public companion object {
 

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
@@ -10,6 +10,7 @@ public open class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
     private val defaultLossless = encoderOptions.lossless
 
     init {
+        WebPWrapper.cleaner.register(this, encoderOptions)
         canWriteCompressed = true
         compressionTypes = CompressionType.imageIoCompressionTypes
         compressionMode = MODE_EXPLICIT
@@ -32,7 +33,7 @@ public open class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
     }
 
     public var compressionType: CompressionType
-        get() = CompressionType.values().first { it.imageIoValue == getCompressionType() }
+        get() = CompressionType.entries.first { it.imageIoValue == getCompressionType() }
         set(value) {
             setCompressionType(value.imageIoValue)
         }
@@ -40,7 +41,7 @@ public open class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
     override fun setCompressionType(compressionType: String) {
         super.setCompressionType(compressionType)
 
-        encoderOptions.lossless = when (CompressionType.values().firstOrNull { it.imageIoValue == compressionType }) {
+        encoderOptions.lossless = when (CompressionType.entries.firstOrNull { it.imageIoValue == compressionType }) {
             CompressionType.Lossless -> true
             CompressionType.Lossy -> false
             null -> error("unrecognised compression type=$compressionType")

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/VP8StatusCode.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/VP8StatusCode.kt
@@ -13,6 +13,6 @@ internal enum class VP8StatusCode {
 
     companion object {
 
-        fun getStatusCode(aValue: Int) = values().getOrNull(aValue)
+        fun getStatusCode(aValue: Int) = entries.getOrNull(aValue)
     }
 }

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWrapper.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWrapper.kt
@@ -10,11 +10,14 @@ import com.luciad.imageio.webp.WebP.getInfo
 import com.luciad.imageio.webp.internal.NativeLoader.initialize
 import com.luciad.imageio.webp.internal.VP8StatusCode
 import java.io.IOException
+import java.lang.ref.Cleaner
 import java.nio.ByteOrder
 
 internal object WebPWrapper {
 
     private var NATIVE_LIBRARY_LOADED = false
+
+    val cleaner: Cleaner = Cleaner.create()
 
     init {
         loadNativeLibrary()

--- a/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/utils/TestUtils.kt
+++ b/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/utils/TestUtils.kt
@@ -18,9 +18,12 @@ import javax.imageio.stream.MemoryCacheImageInputStream
 internal fun Iterator<ImageReader>.requireWebpImageReader() = asSequence().single { it.originatingProvider is WebPImageReaderSpi }
 internal fun Iterator<ImageWriter>.requireWebpImageWriter() = asSequence().single { it.originatingProvider is WebPImageWriterSpi }
 
-internal fun readImage(webp: ByteArray, param: ImageReadParam? = null) = getImageReader(webp)
-    .apply { input = MemoryCacheImageInputStream(ByteArrayInputStream(webp)) }
-    .read(0, param)
+internal fun readImage(webp: ByteArray, param: ImageReadParam? = null) =
+    MemoryCacheImageInputStream(ByteArrayInputStream(webp)).use { input ->
+        getImageReader(webp)
+            .apply { this.input = input }
+            .read(0, param)
+    }
 
 private fun getImageReader(data: ByteArray): ImageReader {
     val stream = MemoryCacheImageInputStream(ByteArrayInputStream(data))


### PR DESCRIPTION
Fixes https://github.com/usefulness/webp-imageio/issues/91