### PR TITLE
Change exception thrown when invalid `imageIndex` is passed

### DIFF
--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPReader.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPReader.kt
@@ -24,6 +24,7 @@ import java.awt.image.DirectColorModel
 import java.awt.image.WritableRaster
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.lang.IndexOutOfBoundsException
 import java.util.Hashtable
 import javax.imageio.ImageReadParam
 import javax.imageio.ImageReader
@@ -87,7 +88,9 @@ internal class WebPReader(originatingProvider: ImageReaderSpi) : ImageReader(ori
     }
 
     private fun checkIndex(imageIndex: Int) {
-        require(imageIndex == 0) { "Invalid image index: $imageIndex" }
+        if (imageIndex != 0) {
+            throw IndexOutOfBoundsException("Invalid image index")
+        }
     }
 
     override fun getWidth(imageIndex: Int): Int {

--- a/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/WebPImageReaderSpiTest.kt
+++ b/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/WebPImageReaderSpiTest.kt
@@ -1,0 +1,25 @@
+package com.luciad.imageio.webp
+
+import com.luciad.imageio.webp.utils.getImageReader
+import com.luciad.imageio.webp.utils.readResource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import javax.imageio.stream.MemoryCacheImageInputStream
+
+class WebPImageReaderSpiTest {
+
+    @Test
+    fun throwsProperException() {
+        val result = runCatching {
+            val resource = readResource("lossy.webp")
+            MemoryCacheImageInputStream(ByteArrayInputStream(resource)).use { input ->
+                getImageReader(resource)
+                    .apply { this.input = input }
+                    .read(2, null)
+            }
+        }
+
+        assertThat(result.exceptionOrNull()).isInstanceOf(IndexOutOfBoundsException::class.java)
+    }
+}

--- a/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/utils/TestUtils.kt
+++ b/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/utils/TestUtils.kt
@@ -25,7 +25,7 @@ internal fun readImage(webp: ByteArray, param: ImageReadParam? = null) =
             .read(0, param)
     }
 
-private fun getImageReader(data: ByteArray): ImageReader {
+internal fun getImageReader(data: ByteArray): ImageReader {
     val stream = MemoryCacheImageInputStream(ByteArrayInputStream(data))
 
     return ImageIO.getImageReaders(stream).requireWebpImageReader()


### PR DESCRIPTION
https://github.com/usefulness/webp-imageio/issues/136