### PR TITLE
Revert "Update dependency com.android.tools:r8 to v8.9.35"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ maven-junit = "5.12.2"
 maven-assertj = "3.27.3"
 maven-binarycompatiblity = "0.17.0"
 maven-dokka = "2.0.0"
-google-r8 = "8.9.35"
+google-r8 = "8.7.18"
 
 [libraries]
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "maven-junit" }


### PR DESCRIPTION
Reverts usefulness/webp-imageio#273

Due to: https://issuetracker.google.com/issues/413061410