### PR TITLE
Fix for Issue 164

### DIFF
--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPCleaner.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPCleaner.java
@@ -1,9 +1,0 @@
-package com.luciad.imageio.webp;
-
-import java.lang.ref.Cleaner;
-
-public class WebPCleaner {
-
-  static final Cleaner cleaner  = Cleaner.create();
-
-}

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPCleaner.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPCleaner.java
@@ -1,0 +1,9 @@
+package com.luciad.imageio.webp;
+
+import java.lang.ref.Cleaner;
+
+public class WebPCleaner {
+
+  static final Cleaner cleaner  = Cleaner.create();
+
+}

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
@@ -15,7 +15,11 @@
  */
 package com.luciad.imageio.webp;
 
+import java.lang.ref.Cleaner;
+
 final class WebPDecoderOptions implements Runnable {
+
+  static private final Cleaner cleaner  = Cleaner.create();
 
   long fPointer;
 
@@ -23,6 +27,8 @@ final class WebPDecoderOptions implements Runnable {
     fPointer = createDecoderOptions();
     if (fPointer == 0) {
       throw new OutOfMemoryError();
+    } else {
+      cleaner.register(this,this);
     }
   }
 

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
@@ -15,11 +15,9 @@
  */
 package com.luciad.imageio.webp;
 
-import java.lang.ref.Cleaner;
+import static com.luciad.imageio.webp.WebPCleaner.cleaner;
 
 final class WebPDecoderOptions implements Runnable {
-
-  static private final Cleaner cleaner  = Cleaner.create();
 
   long fPointer;
 

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPDecoderOptions.java
@@ -15,7 +15,6 @@
  */
 package com.luciad.imageio.webp;
 
-import static com.luciad.imageio.webp.WebPCleaner.cleaner;
 
 final class WebPDecoderOptions implements Runnable {
 
@@ -25,9 +24,9 @@ final class WebPDecoderOptions implements Runnable {
     fPointer = createDecoderOptions();
     if (fPointer == 0) {
       throw new OutOfMemoryError();
-    } else {
-      cleaner.register(this,this);
     }
+
+    WebPWrapper.cleaner.register(this, this);
   }
 
   @Override

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
@@ -15,7 +15,6 @@
  */
 package com.luciad.imageio.webp;
 
-import static com.luciad.imageio.webp.WebPCleaner.cleaner;
 
 final class WebPEncoderOptions implements Runnable {
 
@@ -25,9 +24,9 @@ final class WebPEncoderOptions implements Runnable {
     fPointer = createConfig();
     if (fPointer == 0) {
       throw new OutOfMemoryError();
-    } else {
-      cleaner.register(this,this);
     }
+
+    WebPWrapper.cleaner.register(this, this);
   }
 
   @Override

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
@@ -15,14 +15,20 @@
  */
 package com.luciad.imageio.webp;
 
+import java.lang.ref.Cleaner;
+
 final class WebPEncoderOptions implements Runnable {
 
-  long fPointer;
+  static private final Cleaner cleaner  = Cleaner.create();
+
+  private long fPointer;
 
   public WebPEncoderOptions() {
     fPointer = createConfig();
     if (fPointer == 0) {
       throw new OutOfMemoryError();
+    } else {
+      cleaner.register(this,this);
     }
   }
 

--- a/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
+++ b/webp-imageio/src/main/java/com/luciad/imageio/webp/WebPEncoderOptions.java
@@ -15,11 +15,9 @@
  */
 package com.luciad.imageio.webp;
 
-import java.lang.ref.Cleaner;
+import static com.luciad.imageio.webp.WebPCleaner.cleaner;
 
 final class WebPEncoderOptions implements Runnable {
-
-  static private final Cleaner cleaner  = Cleaner.create();
 
   private long fPointer;
 

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPReadParam.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPReadParam.kt
@@ -7,10 +7,6 @@ public class WebPReadParam : ImageReadParam() {
 
     internal val decoderOptions = WebPDecoderOptions()
 
-    init {
-        WebPWrapper.cleaner.register(decoderOptions, decoderOptions)
-    }
-
     /**
      * if true, skip the in-loop filtering
      */

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPReadParam.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPReadParam.kt
@@ -8,7 +8,7 @@ public class WebPReadParam : ImageReadParam() {
     internal val decoderOptions = WebPDecoderOptions()
 
     init {
-        WebPWrapper.cleaner.register(this, decoderOptions)
+        WebPWrapper.cleaner.register(decoderOptions, decoderOptions)
     }
 
     /**

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
@@ -10,7 +10,6 @@ public class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
     private val defaultLossless = encoderOptions.lossless
 
     init {
-        WebPWrapper.cleaner.register(encoderOptions, encoderOptions)
         canWriteCompressed = true
         compressionTypes = CompressionType.imageIoCompressionTypes
         compressionMode = MODE_EXPLICIT

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt
@@ -10,7 +10,7 @@ public class WebPWriteParam(locale: Locale?) : ImageWriteParam(locale) {
     private val defaultLossless = encoderOptions.lossless
 
     init {
-        WebPWrapper.cleaner.register(this, encoderOptions)
+        WebPWrapper.cleaner.register(encoderOptions, encoderOptions)
         canWriteCompressed = true
         compressionTypes = CompressionType.imageIoCompressionTypes
         compressionMode = MODE_EXPLICIT

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWrapper.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWrapper.kt
@@ -10,11 +10,15 @@ import com.luciad.imageio.webp.WebP.getInfo
 import com.luciad.imageio.webp.internal.NativeLoader.initialize
 import com.luciad.imageio.webp.internal.VP8StatusCode
 import java.io.IOException
+import java.lang.ref.Cleaner
 import java.nio.ByteOrder
 
 internal object WebPWrapper {
 
     private var NATIVE_LIBRARY_LOADED = false
+
+    @JvmField
+    val cleaner: Cleaner = Cleaner.create()
 
     init {
         loadNativeLibrary()

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWrapper.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWrapper.kt
@@ -10,14 +10,11 @@ import com.luciad.imageio.webp.WebP.getInfo
 import com.luciad.imageio.webp.internal.NativeLoader.initialize
 import com.luciad.imageio.webp.internal.VP8StatusCode
 import java.io.IOException
-import java.lang.ref.Cleaner
 import java.nio.ByteOrder
 
 internal object WebPWrapper {
 
     private var NATIVE_LIBRARY_LOADED = false
-
-    val cleaner: Cleaner = Cleaner.create()
 
     init {
         loadNativeLibrary()

--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWriter.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWriter.kt
@@ -62,22 +62,13 @@ internal class WebPWriter(originatingProvider: ImageWriterSpi?) : ImageWriter(or
     companion object {
 
         private fun encode(options: WebPEncoderOptions, image: RenderedImage): ByteArray {
-            // This prevents the JVM/GC from attempting to GC (during periods of high load) when it no longer sees any of the
-            // variables being referred to any further, despite the underlying WebP library directly using them.
-            // https://bitbucket.org/luciad/webp-imageio/pull-requests/3/prevent-webpencoderoptionss-finalizer/diff
-            val encoderThreadLocal = ThreadLocal<WebPEncoderOptions>()
-            return try {
-                encoderThreadLocal.set(options)
-                val encodeAlpha = hasTranslucency(image)
-                if (encodeAlpha) {
-                    val rgbaData = getRGBA(image)
-                    WebPWrapper.encodeRGBA(options, rgbaData, image.width, image.height, image.width * 4)
-                } else {
-                    val rgbData = getRGB(image)
-                    WebPWrapper.encodeRGB(options, rgbData, image.width, image.height, image.width * 3)
-                }
-            } finally {
-                encoderThreadLocal.remove()
+            val encodeAlpha = hasTranslucency(image)
+            return if (encodeAlpha) {
+                val rgbaData = getRGBA(image)
+                WebPWrapper.encodeRGBA(options, rgbaData, image.width, image.height, image.width * 4)
+            } else {
+                val rgbData = getRGB(image)
+                WebPWrapper.encodeRGB(options, rgbData, image.width, image.height, image.width * 3)
             }
         }
 


### PR DESCRIPTION
Regarding #164 :

`WebPWriteParam` registers the `WebPEncoderOptions` in the cleaner, with itself being the monitored object:

https://github.com/usefulness/webp-imageio/blob/7dc76399bd570a36c33a1a57e6a8ad357f56b7bf/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/WebPWriteParam.kt#L13

But it leaks a reference to `WebPEncoderOptions` right here:

https://github.com/usefulness/webp-imageio/blob/7dc76399bd570a36c33a1a57e6a8ad357f56b7bf/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWriter.kt#L56

That means, `WebPWriteParam` could become eligible for garbage collection, thus triggering the `Cleaner` calling `WebPEncoderOptions`'s `run`, while a reference to that `WebPEncoderOptions` is still out there in the wild.

The workaround doesn't help:

https://github.com/usefulness/webp-imageio/blob/7dc76399bd570a36c33a1a57e6a8ad357f56b7bf/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/WebPWriter.kt#L64-L69

Basically, it's enough to change `WebPWrapper.cleaner.register(this, encoderOptions)`to `WebPWrapper.cleaner.register(encoderOptions, encoderOptions)` (and that's basically, what the first commit does).

However, since it's `WebPEncoderOptions` which is allocating memory outside the jvm, it should also be its responsibility to ensure cleanup. This is what the second commit does: `WebPEncoderOptions` use a `Cleaner` to do so.

All of that also applies to `WebPReadParam` and`WebPDecoderOptions`.

I couldn't reproduce the issue with any of those two commits.