### PR TITLE
Disable Alpine Linux detection

### DIFF
--- a/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/OsInfo.kt
+++ b/webp-imageio/src/main/kotlin/com/luciad/imageio/webp/internal/OsInfo.kt
@@ -188,9 +188,8 @@ internal object OsInfo {
     private fun translateOSNameToFolderName(osName: String) = when {
         osName.contains("Windows") -> "Windows"
         osName.contains("Mac") || osName.contains("Darwin") -> "Mac"
-        isAlpine -> "Linux-Alpine"
+        isAlpine -> "Linux"
         osName.contains("Linux") -> "Linux"
-        osName.contains("AIX") -> "AIX"
         else -> osName.replace("\\W".toRegex(), "")
     }
 


### PR DESCRIPTION
https://github.com/usefulness/webp-imageio/issues/303

Given there are no dedicated native binaries for Alpine Linux let's continue falling back to `/Linux` like it was before v0.10.1 🤷 