### PR TITLE
Bump manylinux cross images to 2014 for libwebp 1.6.0 AVX2 build

### DIFF
--- a/libwebp-jni/dockcross/dockcross-manylinux-x64
+++ b/libwebp-jni/dockcross/dockcross-manylinux-x64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2010-x64:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x64:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/libwebp-jni/dockcross/dockcross-manylinux-x86
+++ b/libwebp-jni/dockcross/dockcross-manylinux-x86
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2010-x86:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x86:latest
 
 #------------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Problem

The [Build binaries](https://github.com/usefulness/webp-imageio/actions/runs/27539225095) workflow (dispatched for libwebp **v1.6.0**) fails on the **Linux x86 (32-bit)** target:

```
lossless_enc_avx2.c:408: warning: implicit declaration of '_mm256_storeu2_m128i'
libwebp.a(lossless_avx2.c.o): undefined reference to '_mm256_cvtsi256_si32'
collect2: error: ld returned 1 exit status
```

libwebp 1.6.0 added new AVX2 lossless code (`lossless_avx2.c`, `lossless_enc_avx2.c`) using `_mm256_storeu2_m128i` and `_mm256_cvtsi256_si32`. The GCC shipped in the `dockcross/manylinux2010-*` images doesn't declare these intrinsics, so the AVX2 path compiles with a warning and then fails at link.

## Fix

Bump both the x86 and x64 dockcross images from `manylinux2010` to `manylinux2014` (GCC 10), which provides the required intrinsic headers. The x64 image is bumped too since it builds the same AVX2 sources and would hit the identical link error once x86 passes.

## Verification

Not yet run end-to-end — re-dispatch the `Build binaries` workflow with `libwebp_ref=v1.6.0` on this branch to confirm all targets build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)