### PR TITLE
Fix libwebp 1.6.0 binary build: use GCC 12/14 cross toolchains

### DIFF
--- a/libwebp-jni/compile-all.sh
+++ b/libwebp-jni/compile-all.sh
@@ -9,7 +9,7 @@ df -H
 ./dockcross/dockcross-linux-armv6-lts bash -c './compile.sh Linux armv6'
 ./dockcross/dockcross-linux-armv7-lts bash -c './compile.sh Linux armv7'
 ./dockcross/dockcross-linux-arm64-lts bash -c './compile.sh Linux aarch64'
-./dockcross/dockcross-manylinux-x86 bash -c './compile.sh Linux x86'
+./dockcross/dockcross-linux-x86 bash -c './compile.sh Linux x86'
 ./dockcross/dockcross-manylinux-x64 bash -c './compile.sh Linux x86_64'
 ./dockcross/dockcross-linux-ppc64le bash -c './compile.sh Linux ppc64'
 

--- a/libwebp-jni/dockcross/dockcross-linux-x86
+++ b/libwebp-jni/dockcross/dockcross-linux-x86
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x86:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-x86:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/libwebp-jni/dockcross/dockcross-manylinux-x64
+++ b/libwebp-jni/dockcross/dockcross-manylinux-x64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux2014-x64:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/manylinux_2_28-x64:latest
 
 #------------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Background

#390 bumped the manylinux cross images `2010 → 2014` to fix the [Build binaries](https://github.com/usefulness/webp-imageio/actions/runs/27540061875) failure on libwebp **v1.6.0**, but it doesn't work: **manylinux2014 also ships GCC 10**, which is the exact compiler that fails.

## Root cause

libwebp 1.6.0 added AVX2 lossless code (`lossless_avx2.c`, `lossless_enc_avx2.c`) using `_mm256_cvtsi256_si32` and `_mm256_storeu2_m128i`. These intrinsics are **absent in GCC 8 and GCC 10** but present in **GCC 12/14** (verified directly in the containers). The build fails at link:

```
lossless_avx2.c: undefined reference to '_mm256_cvtsi256_si32'
collect2: error: ld returned 1 exit status
```

libwebp 1.6.0 exposes no per-feature AVX2 toggle (only the global `WEBP_ENABLE_SIMD`), so disabling just AVX2 isn't possible — a newer compiler is the only fix that keeps SIMD.

## Change

| Target | Was | Now | Compiler | glibc floor |
|--------|-----|-----|----------|-------------|
| x86_64 | manylinux2014-x64 | **manylinux_2_28-x64** | GCC 14 | 2.12 → 2.28 |
| x86 (32-bit) | manylinux2014-x86 | **dockcross/linux-x86** | GCC 12 | 2.12 → 2.36 |

`manylinux_2_28` has no i686 variant and CentOS 7's devtoolset-11 is no longer installable (EOL repos), so `dockcross/linux-x86` (Debian 12, GCC 12) is the only available i686 toolchain new enough to compile the AVX2 intrinsics.

## Trade-off

The shipped native `.so` files will require a **newer runtime glibc** than the old manylinux2010 build (x86_64 ≥ 2.28, x86 ≥ 2.36). AVX2 itself needs a 2013+ CPU, but the glibc bump affects loading on older distros regardless of CPU. This is the unavoidable cost of building the new AVX2 code.

## Verification

Confirmed in `dockcross/linux-x86` (GCC 12, i686) and `dockcross/manylinux_2_28-x64` (GCC 14) that both intrinsics compile and link cleanly into a shared object. **Not yet validated end-to-end** — the real test is dispatching the `Build binaries` workflow with `libwebp_ref=v1.6.0` against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)