### PR TITLE
Upgrade JUnit 5.14.4 to 6.0.3

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: |
-            11
             17
             21
             24

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 gradle-starter = "0.96.1"
 gradle-doctor = "0.12.1"
 gradle-gradleup-shadow = "9.4.2"
-maven-junit = "5.14.4"
+maven-junit = "6.0.3"
 maven-assertj = "3.27.7"
 maven-binarycompatiblity = "0.18.1"
 maven-dokka = "2.2.0"

--- a/webp-imageio/build.gradle
+++ b/webp-imageio/build.gradle
@@ -8,6 +8,14 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 
+// JUnit 6 requires a JVM 17 runtime. The library itself targets Java 9, but the test
+// classpath must advertise JVM 17 so variant-aware resolution accepts the JUnit 6 artifacts.
+[configurations.testCompileClasspath, configurations.testRuntimeClasspath].each { config ->
+    config.attributes {
+        attribute(org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+    }
+}
+
 tasks.withType(JavaCompile).configureEach {
     options.headerOutputDirectory.set(rootProject.file("libwebp-jni/src/main/c"))
 }
@@ -27,7 +35,7 @@ tasks.register("generateVersionProperties", WriteProperties) { WriteProperties p
     props.property("webp_imageio_version", version)
 }
 
-[11, 17, 21].forEach { majorVersion ->
+[17, 21].forEach { majorVersion ->
     def jdkTest = tasks.register("testJdk$majorVersion", Test) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(majorVersion)

--- a/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/WebPTest.kt
+++ b/webp-imageio/src/test/kotlin/com/luciad/imageio/webp/WebPTest.kt
@@ -8,8 +8,6 @@ import com.luciad.imageio.webp.utils.requireWebpImageWriter
 import com.luciad.imageio.webp.utils.writeWebpImage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.DisabledOnJre
-import org.junit.jupiter.api.condition.JRE
 import org.junit.jupiter.api.io.TempDir
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferInt
@@ -86,7 +84,6 @@ class WebPTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_9) // for some reason Java 9 can't read JPEGs with indexed colors
     fun nonRgbColorSpace(@TempDir tempDir: Path) {
         val inputImage1 = ImageIO.read(readResource("non_rgb_1.jpg").inputStream())
         val inputImage2 = ImageIO.read(readResource("non_rgb_2.jpeg").inputStream())


### PR DESCRIPTION
## What

Upgrades JUnit from `5.14.4` to `6.0.3`.

`5.14.4` is already the latest 5.x release, so `6.0.3` is the only available upgrade. JUnit 6 raises its **runtime baseline to Java 17**.

## Why this touches more than the version catalog

JUnit is a test-only dependency and the published library still compiles to **Java 9** — that is unchanged (verified: class-file major version 53). However, `commonConfig { javaVersion = VERSION_1_9 }` propagates the Java 9 target to the *test* source set too, so Gradle's variant-aware resolution rejected JUnit 6 on a Java-9 test classpath:

> `'org.junit.jupiter:junit-jupiter-api:6.0.3' is only compatible with JVM runtime version 17 or newer`

## Changes

- **`gradle/libs.versions.toml`** — `maven-junit` `5.14.4` → `6.0.3`.
- **`webp-imageio/build.gradle`**
  - Override `TargetJvmVersion = 17` on `testCompileClasspath`/`testRuntimeClasspath` so JUnit 6 resolves, while the library keeps targeting Java 9.
  - Drop JDK 11 from the per-JDK test loop (`[11, 17, 21]` → `[17, 21]`); JUnit 6 cannot run on JDK 11, so `testJdk11` is removed.
- **`webp-imageio/src/test/kotlin/.../WebPTest.kt`** — remove the now-dead `@DisabledOnJre(JRE.JAVA_9)` annotation and its imports (tests no longer run on Java 9; the enum entry is deprecated in JUnit 6).
- **`.github/workflows/default.yml`** — drop JDK 11 from provisioned JDKs since no task selects it anymore.

## Verification

- `./gradlew check assemble` is green; `test`, `testJdk17`, `testJdk21` all pass.
- Confirmed `testJdk11` no longer exists.
- Confirmed the main library artifact still targets Java 9 (bytecode major version 53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)